### PR TITLE
Updated for Django 1.9

### DIFF
--- a/likes/templatetags/likes_inclusion_tags.py
+++ b/likes/templatetags/likes_inclusion_tags.py
@@ -21,7 +21,7 @@ def likes(context, obj, template=None):
         'content_obj': obj,
         'likes_enabled': likes_enabled(obj, request),
         'can_vote': can_vote(obj, request.user, request),
-        'content_type': "-".join((obj._meta.app_label, obj._meta.module_name)),
+        'content_type': "-".join((obj._meta.app_label, obj._meta.model_name)),
         'import_js': import_js
     })
     return context

--- a/likes/urls.py
+++ b/likes/urls.py
@@ -3,8 +3,8 @@ try:
 except ImportError:
     from django.conf.urls import patterns, url
 
-urlpatterns = patterns(
-    'likes.views',
-    url(r'^like/(?P<content_type>[\w-]+)/(?P<id>\d+)/(?P<vote>-?\d+)$', 'like',
-        name='like'),
-)
+from likes.views import like
+
+urlpatterns = [
+    url(r'^like/(?P<content_type>[\w-]+)/(?P<id>\d+)/(?P<vote>-?\d+)$', like,name='like'),
+]


### PR DESCRIPTION
Use of patterns has been deprecated and replaced with a list
Use of URL strings has been deprecated and been replaced with an object
Use of meta.module_name has been deprecated and replaced with
meta.model_name
